### PR TITLE
Fix support for non-default diary location

### DIFF
--- a/diary-read
+++ b/diary-read
@@ -3,7 +3,7 @@ ENTRIES_DIR=${DIARY_DIRECTORY:-"~/diary"}
 GPG_CMD=${DIARY_GPG:-"gpg2"}
 READER=${DIARY_READER:-"less"}
 (
-for file in ~/diary/*; do
+for file in $ENTRIES_DIR/*; do
 	echo "---------------- $(basename $file .gpg) ------------"
 	$GPG_CMD --decrypt --output "-" --yes --quiet $file
 	echo 


### PR DESCRIPTION
I started using this project, but I noticed a really small bug in the `diary-read` script: a custom diary location isn't honoured!

This pull request fixes the problem, by using the `ENTRIES_DIR` variable, which is determined earlier.  I hope you find it useful.